### PR TITLE
Fix this shitty eslint with .vue files

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
-    "lint": "eslint src/",
-    "cs-fix": "eslint --fix src/",
+    "lint": "eslint src/ --ext .js,.vue",
+    "cs-fix": "eslint --fix src/ --ext .js,.vue",
     "postinstall": "npm run build",
     "start": "node server.js"
   },


### PR DESCRIPTION
À ajouter dans votre config IDE pour pouvoir linter correctement les `.vue` (pour VS Code) :

```
"eslint.validate": [
    "javascript",
    "javascriptreact",
    {
        "language": "vue",
        "autoFix": true
    }
],
```

https://alligator.io/vuejs/vue-eslint-plugin/#editor-configuration